### PR TITLE
Fixed paths in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ You will need a server running Debian 10 with SSH key auth.
 
 ## Usage
 
+First of all, clone this repository and cd into the newly created directory.
+
 Configure:
 
-* Rename the inventory file `contrib/ansible/inventory/example` to `server` and replace the servername in it.
-* Rename the configuration file `contrib/ansible/inventory/host_vars/server.example.com.yml` to match the servername in your inventory file.
+* Rename the inventory file `inventory/example` to `server` and replace the servername in it.
+* Rename the configuration file `inventory/host_vars/server.example.com.yml` to match the servername in your inventory file.
 * Edit the configuration file to your needs.
 
 Run:
 
 ```sh
-cd contrib/ansible
-
 # Method 1
 # 
 # Connect as your_user and sudo with the password ansible asks you

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Run:
 # Method 1
 # 
 # Connect as your_user and sudo with the password ansible asks you
-ansible-playbook -u your_user -b -K -i inventory/server
+ansible-playbook -u your_user -b -K -i inventory/server site.yml
 
 # Method 2
 #
 # Connect as root
-ansible-playbook -u root -i inventory/server
+ansible-playbook -u root -i inventory/server site.yml
 ```
 
 ## Install Ansible


### PR DESCRIPTION
As the Ansible playbook for the Engelsystem now resides in its own repository, the `contrib/ansible` prefix and `cd contrib/ansible` command have to be removed.