### PR TITLE
Allow engelsystem role to install only dependencies

### DIFF
--- a/inventory/host_vars/server.example.com.yml
+++ b/inventory/host_vars/server.example.com.yml
@@ -3,6 +3,7 @@
 # engelsystem
 #
 
+engelsystem_base_dir: /opt/engelsystem
 engelsystem_version: v3.0.0
 engelsystem_servername: engel.example.com
 engelsystem_mysql_root_password: password

--- a/roles/engelsystem/defaults/main.yml
+++ b/roles/engelsystem/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 
+engelsystem_base_dir: /opt/engelsystem
+engelsystem_tls_base: /etc/letsencrypt/live
 engelsystem_version: v3.0.0
 engelsystem_servername: engel.example.com
 engelsystem_mysql_root_password: password

--- a/roles/engelsystem/handlers/main.yml
+++ b/roles/engelsystem/handlers/main.yml
@@ -7,5 +7,5 @@
 
 - name: engelsystem_migratedb
   shell: |
-    cd ~engelsystem/latest
+    cd ~engelsystem/current
     ./bin/migrate

--- a/roles/engelsystem/tasks/main.yml
+++ b/roles/engelsystem/tasks/main.yml
@@ -8,11 +8,9 @@
     pkg:
       - nginx
       - php-fpm
-      - php-gettext
       - php-json
       - php-mbstring
       - php-mysql
-      - php-tokenizer
       - php-xml
       - mariadb-server
       - mariadb-client
@@ -33,70 +31,74 @@
 - name: engelsystem_user
   user:
     name: engelsystem
-    home: /opt/engelsystem
+    home: "{{ engelsystem_base_dir }}"
     system: yes
 
 - name: engelsystem_versiondir
   file:
     state: directory
-    dest: "/opt/engelsystem/{{ engelsystem_version }}"
+    dest: "{{ engelsystem_base_dir }}/{{ engelsystem_version }}"
     owner: engelsystem
     group: www-data
 
 - name: engelsystem_download
   unarchive:
     src: "https://github.com/engelsystem/engelsystem/releases/download/{{ engelsystem_version }}/engelsystem-{{ engelsystem_version }}.zip"
-    dest: "/opt/engelsystem/{{ engelsystem_version }}"
-    creates: "/opt/engelsystem/{{ engelsystem_version }}/release"
+    dest: "{{ engelsystem_base_dir }}/{{ engelsystem_version }}"
+    creates: "{{ engelsystem_base_dir }}/{{ engelsystem_version }}/release"
     owner: engelsystem
     group: www-data
     remote_src: yes
+  when: "engelsystem_version in ['v2.0.0', 'v3.0.0']"
   notify:
     - engelsystem_migratedb
 
 - name: engelsystem_writables
   file:
-    dest: "/opt/engelsystem/{{ engelsystem_version }}/release/{{ item }}"
+    dest: "{{ engelsystem_base_dir }}/{{ engelsystem_version }}/release/{{ item }}"
     state: directory
     mode: "0770"
   loop:
     - import
     - storage
+  when: "engelsystem_version in ['v2.0.0', 'v3.0.0']"
 
-- name: engelsystem_latest
+- name: engelsystem_current
   file:
     state: link
-    src: "/opt/engelsystem/{{ engelsystem_version }}/release"
-    dest: /opt/engelsystem/latest
+    src: "{{ engelsystem_base_dir }}/{{ engelsystem_version }}/release"
+    dest: "{{ engelsystem_base_dir }}/current"
+  when: "engelsystem_version in ['v2.0.0', 'v3.0.0']"
 
 - name: engelsystem_config
   template:
     src: config.php.j2
-    dest: "/opt/engelsystem/{{ engelsystem_version }}/release/config/config.php"
+    dest: "{{ engelsystem_base_dir }}/{{ engelsystem_version }}/release/config/config.php"
+  when: "engelsystem_version in ['v2.0.0', 'v3.0.0']"
 
 - name: engelsystem_checkcert
   stat:
-    path: "/etc/letsencrypt/live/{{ engelsystem_servername }}/fullchain.pem"
+    path: "{{ engelsystem_tls_base }}/{{ engelsystem_servername }}/fullchain.pem"
   register: engelsystem_ssl
 
 - name: engelsystem_nginxconfig
   template:
     src: nginx_vhost.conf.j2
     dest: /etc/nginx/sites-enabled/engelsystem.conf
-  when: certbot_skip or not engelsystem_ssl.stat.exists
+  when: not engelsystem_ssl.stat.exists
   notify:
     - engelsystem_nginxreload
 
 - name: engelsystem_certbot
   include_tasks:
     file: certbot.yml
-  when: not certbot_skip and not engelsystem_ssl.stat.exists
+  when: not certbot_skip
 
 - name: engelsystem_nginxconfig
   template:
     src: nginx_vhost_ssl.conf.j2
     dest: /etc/nginx/sites-enabled/engelsystem.conf
-  when: not certbot_skip
+  when: engelsystem_ssl.stat.exists
   notify:
     - engelsystem_nginxreload
 

--- a/roles/engelsystem/templates/nginx_vhost.conf.j2
+++ b/roles/engelsystem/templates/nginx_vhost.conf.j2
@@ -3,7 +3,7 @@ server {
     listen [::]:80;
 
     server_name {{ engelsystem_servername }};
-    root /opt/engelsystem/latest/public;
+    root {{ engelsystem_base_dir }}/current/public;
 
     location / {
         try_files $uri /index.php$is_args$args;

--- a/roles/engelsystem/templates/nginx_vhost_ssl.conf.j2
+++ b/roles/engelsystem/templates/nginx_vhost_ssl.conf.j2
@@ -10,11 +10,11 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    ssl_certificate /etc/letsencrypt/live/{{ engelsystem_servername }}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/{{ engelsystem_servername }}/privkey.pem;
+    ssl_certificate {{ engelsystem_tls_base }}/{{ engelsystem_servername }}/fullchain.pem;
+    ssl_certificate_key {{ engelsystem_tls_base }}/{{ engelsystem_servername }}/privkey.pem;
 
     server_name {{ engelsystem_servername }};
-    root /opt/engelsystem/latest/public;
+    root {{ engelsystem_base_dir }}/current/public;
 
     location / {
         try_files $uri /index.php$is_args$args;


### PR DESCRIPTION
Currently, it is only possible to use the v2.0.0 and v3.0.0 Engelsystem releases from GitHub. To be able to also use upstream Engelsystem builds, the Ansible role should be capable of installing the dependencies (MySQL, Nginx, PHP extensions) and configuring the environment (database, Nginx site) only.